### PR TITLE
Re-export Unit256 type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,7 @@ pub mod utils;
 
 pub use address::Address;
 pub use error::ClarityError;
+pub use num256::Uint256;
 pub use private_key::PrivateKey;
 pub use signature::Signature;
 pub use transaction::Transaction;


### PR DESCRIPTION
This type is used in several public APIs. Re-exporting removes the need for downstream clients to add a dependency on num256.