### PR TITLE
Remove the failure crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ serde = "1.0"
 serde-rlp = "0.1"
 num-bigint = { version = "0.3", default-features = false, features = ["serde"] }
 num-traits = "0.2"
-failure = "0.1"
 serde_bytes = "0.11"
 sha3 = "0.9"
 secp256k1 = { version = "0.19", features = ["recovery"] }
@@ -33,7 +32,6 @@ name = "transaction_tests"
 harness = false
 
 [dev-dependencies]
-failure = "0.1"
 futures = "0.1"
 rand = "0.7"
 rustc-test = "0.3.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,19 +1,89 @@
+use std::fmt;
+use std::num::ParseIntError;
+use std::str::Utf8Error;
+
 /// Custom error implementation that describes possible
 /// error states.
 ///
 /// This is shared by a whole crate.
-#[derive(Fail, Debug)]
-pub enum ClarityError {
-    #[fail(display = "Invalid network id")]
+#[derive(Debug)]
+pub enum Error {
     InvalidNetworkId,
-    #[fail(display = "Invalid V value")]
     InvalidV,
-    #[fail(display = "Invalid S value")]
     InvalidS,
-    #[fail(display = "Invalid signature values")]
     InvalidSignatureValues,
-    #[fail(display = "Zero priv key cannot sign")]
     ZeroPrivKey,
-    #[fail(display = "Invalid private key")]
-    InvalidPrivKey,
+    InvalidPrivKeyLength { got: usize, expected: usize },
+    DecodePrivKey(secp256k1::Error),
+    DecodeRecoveryId(secp256k1::Error),
+    ParseMessage(secp256k1::Error),
+    ParseRecoverableSignature(secp256k1::Error),
+    RecoverSignature(secp256k1::Error),
+    InvalidAddressLength { got: usize, expected: usize },
+    InvalidUtf8(Utf8Error),
+    InvalidHex(ParseIntError),
+    InvalidEip55,
+    InvalidSignatureLength,
+    SerializeRlp, // TODO: error in serde_rlp is not public, cannot include source ...
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::InvalidNetworkId => write!(f, "Invalid network id"),
+            Error::InvalidV => write!(f, "Invalid V value"),
+            Error::InvalidS => write!(f, "Invalid S value"),
+            Error::InvalidSignatureValues => write!(f, "Invalid signature values"),
+            Error::ZeroPrivKey => write!(f, "Zero priv key cannot sign"),
+            Error::InvalidPrivKeyLength { got, expected } => write!(
+                f,
+                "Invalid private key length, got {} expected {}",
+                got, expected
+            ),
+            Error::DecodePrivKey(_) => write!(f, "Failed to decode private key"),
+            Error::DecodeRecoveryId(_) => write!(f, "Failed to decode recovery id"),
+            Error::ParseMessage(_) => write!(f, "Failed to parse message"),
+            Error::ParseRecoverableSignature(_) => {
+                write!(f, "Failed to parse recoverable signature")
+            }
+            Error::RecoverSignature(_) => write!(f, "Failed to recover signature"),
+            Error::InvalidAddressLength { got, expected } => write!(
+                f,
+                "Invalid address length, got {}, expected {}",
+                got, expected
+            ),
+            Error::InvalidUtf8(_) => write!(f, "Failed to parse bytes as utf8"),
+            Error::InvalidHex(_) => write!(f, "Invalid hex character"),
+            Error::InvalidEip55 => write!(f, "Invalid EIP-55 Address encoding"),
+            Error::InvalidSignatureLength => write!(f, "Signature should be exactly 65 bytes long"),
+            Error::SerializeRlp => write!(f, "failed to serialize using RLP-encoding"),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::DecodePrivKey(inner) => Some(inner),
+            Error::DecodeRecoveryId(inner) => Some(inner),
+            Error::ParseMessage(inner) => Some(inner),
+            Error::ParseRecoverableSignature(inner) => Some(inner),
+            Error::RecoverSignature(inner) => Some(inner),
+            Error::InvalidHex(inner) => Some(inner),
+            Error::InvalidUtf8(inner) => Some(inner),
+            _ => None,
+        }
+    }
+}
+
+impl From<Utf8Error> for Error {
+    fn from(e: Utf8Error) -> Self {
+        Error::InvalidUtf8(e)
+    }
+}
+
+impl From<ParseIntError> for Error {
+    fn from(e: ParseIntError) -> Self {
+        Error::InvalidHex(e)
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,12 +60,10 @@
 
 extern crate num_bigint;
 extern crate num_traits;
+extern crate secp256k1;
 extern crate serde;
 extern crate serde_bytes;
 extern crate serde_rlp;
-#[macro_use]
-extern crate failure;
-extern crate secp256k1;
 extern crate sha3;
 #[macro_use]
 extern crate lazy_static;
@@ -88,7 +86,7 @@ pub mod types;
 pub mod utils;
 
 pub use address::Address;
-pub use error::ClarityError;
+pub use error::Error;
 pub use num256::Uint256;
 pub use private_key::PrivateKey;
 pub use signature::Signature;


### PR DESCRIPTION
The failure crate is deprecated in favor of using std::error::Error.

We also unify all error types in the root `Error` type and rename it
from `ClarityError` to `Error`. This avoids stuttering when using the
type from other crates via `clarity::Error`.

Fixes #78.