### PR TITLE
Import updated U256

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clarity"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Michał Papierski <michal@papierski.net>, Justin Kilpatrick <justin@althea.net>"]
 autotests = true
 include = [
@@ -21,7 +21,7 @@ num-traits = "0.2"
 sha3 = "0.10"
 secp256k1 = { version = "0.26", features = ["recovery"] }
 serde_derive = "1.0"
-num256 = "0.4"
+num256 = "0.5"
 serde_bytes= "0.11"
 
 [[test]]

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,19 +1,14 @@
 use crate::Address;
 use num256::Uint256;
+use num_traits::Bounded;
 use std::str::FromStr;
 
 pub fn tt256() -> Uint256 {
-    Uint256::from_str(
-        "115792089237316195423570985008687907853269984665640564039457584007913129639936",
-    )
-    .unwrap() // 2 ** 256
+    Uint256::max_value()
 }
 
 pub fn tt256m1() -> Uint256 {
-    Uint256::from_str(
-        "115792089237316195423570985008687907853269984665640564039457584007913129639935",
-    )
-    .unwrap() // 2 ** 256 - 1
+    Uint256::max_value() - 1u8.into()
 }
 
 pub fn tt255() -> Uint256 {

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,5 +1,4 @@
 use crate::address::Address;
-use crate::constants::tt256;
 use crate::error::Error;
 use crate::opcodes::GTXCOST;
 use crate::opcodes::GTXDATANONZERO;
@@ -110,15 +109,6 @@ fn naive_count_32(haystack: &[u8], needle: u8) -> u32 {
 
 impl Transaction {
     pub fn is_valid(&self) -> bool {
-        if self.gas_price >= tt256()
-            || self.gas_limit >= tt256()
-            || self.value >= tt256()
-            || self.nonce >= tt256()
-        {
-            // Way too high values
-            return false;
-        }
-
         // invalid signature check
         if let Some(sig) = self.signature.clone() {
             if !sig.is_valid() {


### PR DESCRIPTION
As noted in the num256_rs repo bnum was used incorrectly and specified a 16384 bit integer as opposed to a 256 bit one. This upgrade imports the fixed version of num256 and removes some now redundant overflow checks.

Previously it was not notied that tt256 actually should overflow a 256 bit integer since we moved from one integer library with a larger internal width to another. Now that we have proper range checking at the foundational level we can remove some checks and fix our constants.