### PR TITLE
Fixes for EIP1559 tx

### DIFF
--- a/clarity/Cargo.toml
+++ b/clarity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clarity"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["Michał Papierski <michal@papierski.net>, Justin Kilpatrick <justin@althea.net>"]
 autotests = true
 include = [

--- a/web30/Cargo.toml
+++ b/web30/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web30"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["Michal Papierski", "Jehan Tremback", "Justin Kilpatrick"]
 description = "Async endian safe web3 library"
 license = "Apache-2.0"
@@ -11,7 +11,7 @@ repository = "https://github.com/althea-net/web30"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-clarity = {path = "../clarity", version = "1.1.0"}
+clarity = {path = "../clarity", version = "1.2.1"}
 num256 = "0.5"
 futures = "0.3"
 awc = {version = "3.1.1", default-features = false, features=["openssl", "compress-gzip", "compress-zstd"]}

--- a/web30/src/client.rs
+++ b/web30/src/client.rs
@@ -555,7 +555,7 @@ impl Web3 {
         secret: PrivateKey,
         options: Vec<SendTxOption>,
     ) -> Result<Uint256, Web3Error> {
-        let mut max_priority_fee_per_gas = 0u8.into();
+        let mut max_priority_fee_per_gas = 1u8.into();
         let mut gas_limit_multiplier = 1f32;
         let mut gas_limit = None;
         let mut access_list = Vec::new();
@@ -679,6 +679,8 @@ impl Web3 {
         if !transaction.is_valid() {
             return Err(Web3Error::BadInput("About to send invalid tx".to_string()));
         }
+
+        let transaction = transaction.sign(&secret, None);
 
         self.eth_send_raw_transaction(transaction.to_bytes()).await
     }

--- a/web30/src/client.rs
+++ b/web30/src/client.rs
@@ -872,7 +872,7 @@ fn test_chain_id() {
 fn test_net_version() {
     use actix::System;
     let runner = System::new();
-    let web3_xdai = Web3::new("https://dai.altheamesh.com", Duration::from_secs(30));
+    let web3_xdai = Web3::new("https://dai.althea.net", Duration::from_secs(30));
     let web3 = Web3::new("https://eth.althea.net", Duration::from_secs(30));
     runner.block_on(async move {
         assert_eq!(1u64, web3.net_version().await.unwrap());


### PR DESCRIPTION
This updates both clarity and web30 to resolve issue with submitting eip1559 transactions. On the clarity side the single byte v in new format signatures needs to be formated as a singel byte rlp token.

On the web30 side we must actually attach the signatures to our transactions if we want them to go through.