### PR TITLE
EIP1559 improvements + Bump for Web30 v1.1.2 and Clarity v1.2.2

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: 'true'
+    - uses: Swatinem/rust-cache@v2
     - name: Build
       run: cargo build --all --verbose
 
@@ -30,6 +31,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: 'true'
+    - uses: Swatinem/rust-cache@v2
     - name: Unit Tests
       run: cargo test --all --verbose 
 
@@ -41,6 +43,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: 'true'
+    - uses: Swatinem/rust-cache@v2
     - name: Clippy
       run: rustup component add clippy && cargo clippy --all --all-targets --all-features -- -D warnings
 
@@ -63,6 +66,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: 'true'
+    - uses: Swatinem/rust-cache@v2
     - name: cross-compile-mips
       run: cargo install cross && cross test --target mips-unknown-linux-gnu
 
@@ -74,6 +78,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: 'true'
+    - uses: Swatinem/rust-cache@v2
     - name: cross-compile-mips64
       run: cargo install cross && cross test --target mips64-unknown-linux-gnuabi64
 
@@ -86,6 +91,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: 'true'
+    - uses: Swatinem/rust-cache@v2
     - name: cross-compile-arm64
       run: cargo install cross && cross test --target aarch64-unknown-linux-gnu
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 
 members = [
     "clarity",

--- a/clarity/Cargo.toml
+++ b/clarity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clarity"
-version = "1.2.1"
+version = "1.2.2"
 authors = ["Michał Papierski <michal@papierski.net>, Justin Kilpatrick <justin@althea.net>"]
 autotests = true
 include = [

--- a/clarity/src/transaction.rs
+++ b/clarity/src/transaction.rs
@@ -252,8 +252,11 @@ impl Transaction {
                 gas_limit,
                 ..
             } => {
+                // While in theory transactions with zero max priority fee are valid they are rejected
+                // on every chain I can test.
                 if gas_limit.checked_mul(**max_fee_per_gas).is_none()
                     || max_priority_fee_per_gas > max_fee_per_gas
+                    || *max_priority_fee_per_gas == 0u8.into()
                 {
                     return false;
                 }

--- a/web30/Cargo.toml
+++ b/web30/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web30"
-version = "1.1.1"
+version = "1.1.2"
 authors = ["Michal Papierski", "Jehan Tremback", "Justin Kilpatrick"]
 description = "Async endian safe web3 library"
 license = "Apache-2.0"
@@ -11,7 +11,7 @@ repository = "https://github.com/althea-net/web30"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-clarity = {path = "../clarity", version = "1.2.1"}
+clarity = {path = "../clarity", version = "1.2.2"}
 num256 = "0.5"
 futures = "0.3"
 awc = {version = "3.1.1", default-features = false, features=["openssl", "compress-gzip", "compress-zstd"]}

--- a/web30/src/types.rs
+++ b/web30/src/types.rs
@@ -634,6 +634,7 @@ pub enum SendTxOption {
     GasMaxFee(Uint256),
     GasPriorityFee(Uint256),
     GasLimitMultiplier(f32),
+    GasMaxFeeMultiplier(f32),
     GasLimit(Uint256),
     Nonce(Uint256),
     AccessList(Vec<(Address, Vec<Uint256>)>),


### PR DESCRIPTION
This patch makes a few quality of life changes for EIP1559 transactions

1) zero priority fee is now considered invalid, this is true on every chain
   I can test
2) Fix handling of gas price multiplier options in EIP1559 tx builder