### PR TITLE
Split prepare and tx publish

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,30 +58,6 @@ jobs:
     - name: Rustfmt
       run: rustup component add rustfmt && cargo fmt --all -- --check
 
-  cross-compile-mips:
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: 'true'
-    - uses: Swatinem/rust-cache@v2
-    - name: cross-compile-mips
-      run: cargo install cross && cross test --target mips-unknown-linux-gnu
-
-  cross-compile-mips64:
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: 'true'
-    - uses: Swatinem/rust-cache@v2
-    - name: cross-compile-mips64
-      run: cargo install cross && cross test --target mips64-unknown-linux-gnuabi64
-
 
   cross-compile-arm64:
 

--- a/clarity/Cargo.toml
+++ b/clarity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clarity"
-version = "1.2.3"
+version = "1.3.0"
 authors = ["Michał Papierski <michal@papierski.net>, Justin Kilpatrick <justin@althea.net>"]
 autotests = true
 include = [
@@ -16,7 +16,7 @@ edition = "2021"
 serde = "1.0"
 num-traits = "0.2"
 sha3 = "0.10"
-secp256k1 = { version = "0.27", features = ["recovery"] }
+secp256k1 = { version = "0.28", features = ["recovery"] }
 serde_derive = "1.0"
 num256 = "0.5"
 
@@ -29,7 +29,7 @@ rand = "0.8"
 rustc-test = "0.3.0"
 serde_json = "1.0"
 serde_yaml = "0.9"
-criterion = "0.4"
+criterion = "0.5"
 openssl = {version = "0.10", features = ["vendored"]}
 web30 = "1.1"
 

--- a/clarity/src/private_key.rs
+++ b/clarity/src/private_key.rs
@@ -137,7 +137,7 @@ impl PrivateKey {
             let context = object.borrow();
             // Create a Secp256k1 message inside the scope without polluting
             // outside scope.
-            let msg = Message::from_slice(data).unwrap();
+            let msg = Message::from_digest_slice(data).unwrap();
             // Sign the raw hash of RLP encoded transaction data with a private key.
             let sig = context.sign_ecdsa_recoverable(&msg, &sk);
             // Serialize the signature into the "compact" form which means

--- a/clarity/src/signature.rs
+++ b/clarity/src/signature.rs
@@ -226,7 +226,7 @@ impl Signature {
         let v = RecoveryId::from_i32(self.get_signature_v()?.to_i32().ok_or(Error::InvalidV)? - 27)
             .map_err(Error::DecodeRecoveryId)?;
         // A message to recover which is a hash of the transaction
-        let msg = Message::from_slice(hash).map_err(Error::ParseMessage)?;
+        let msg = Message::from_digest_slice(hash).map_err(Error::ParseMessage)?;
 
         // Get the compact form using bytes, and "v" parameter
         let compact = RecoverableSignature::from_compact(&self.to_bytes()[..64], v)

--- a/clarity/src/transaction.rs
+++ b/clarity/src/transaction.rs
@@ -526,8 +526,8 @@ impl Transaction {
                     r: sig.get_r(),
                     s: sig.get_s(),
                 })
-            },
-            (_, _) => tx.set_signature(sig)
+            }
+            (_, _) => tx.set_signature(sig),
         }
         tx
     }

--- a/clarity/src/transaction.rs
+++ b/clarity/src/transaction.rs
@@ -583,6 +583,13 @@ impl Transaction {
         Keccak256::digest(self.to_rlp_bytes()).to_vec()
     }
 
+    /// Generates the TXID of this transaction
+    pub fn txid(&self) -> Uint256 {
+        let hash = self.hash();
+        assert!(hash.len() == 32);
+        Uint256::from_be_bytes(&hash)
+    }
+
     /// Creates a byte representation of this transaction
     pub fn to_bytes(&self) -> Vec<u8> {
         self.to_rlp_bytes()

--- a/web30/Cargo.toml
+++ b/web30/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web30"
-version = "1.1.2"
+version = "1.2.0"
 authors = ["Michal Papierski", "Jehan Tremback", "Justin Kilpatrick"]
 description = "Async endian safe web3 library"
 license = "Apache-2.0"

--- a/web30/src/amm.rs
+++ b/web30/src/amm.rs
@@ -607,9 +607,10 @@ impl Web3 {
         }
 
         trace!("payload is  {:?}", payload);
-        let txid = self
-            .send_transaction(router, payload, 0u32.into(), eth_private_key, options)
+        let tx = self
+            .prepare_transaction(router, payload, 0u32.into(), eth_private_key, options)
             .await?;
+        let txid = self.eth_send_raw_transaction(tx.to_bytes()).await?;
         debug!(
             "txid for uniswap swap is {}",
             display_uint256_as_address(txid)
@@ -827,9 +828,10 @@ impl Web3 {
         }
 
         debug!("payload is  {:?}", payload);
-        let txid = self
-            .send_transaction(router, payload, amount, eth_private_key, options)
+        let tx = self
+            .prepare_transaction(router, payload, amount, eth_private_key, options)
             .await?;
+        let txid = self.eth_send_raw_transaction(tx.to_bytes()).await?;
         debug!(
             "txid for uniswap swap is {}",
             display_uint256_as_address(txid)

--- a/web30/src/amm.rs
+++ b/web30/src/amm.rs
@@ -183,8 +183,8 @@ impl Web3 {
                 fee,
                 swap_res
             );
-            if swap_res.is_ok() {
-                return Ok(swap_res.unwrap());
+            if let Ok(swap_res) = swap_res {
+                return Ok(swap_res);
             }
         }
 
@@ -1007,8 +1007,7 @@ impl Web3 {
         fee: Uint256, // the fee value of the Uniswap pool, in hundredths of basis points (e.g. 0.05% -> 500)
     ) -> Result<Uint256, Web3Error> {
         // Compute a sensible default from sqrt price limit
-        if sqrt_price_limit.is_some() {
-            let sqrt_price_limit = sqrt_price_limit.unwrap();
+        if let Some(sqrt_price_limit) = sqrt_price_limit {
             if sqrt_price_limit == 0u8.into() {
                 return Ok(0u8.into());
             }

--- a/web30/src/client.rs
+++ b/web30/src/client.rs
@@ -13,8 +13,8 @@ use clarity::{Address, PrivateKey, Transaction};
 use futures::future::join4;
 use num256::Uint256;
 use num_traits::{ToPrimitive, Zero};
+use std::time::Instant;
 use std::{cmp::min, time::Duration};
-use std::{sync::Arc, time::Instant};
 use tokio::time::sleep as delay_for;
 
 const ETHEREUM_INTRINSIC_GAS: u32 = 21000;
@@ -23,14 +23,14 @@ const ETHEREUM_INTRINSIC_GAS: u32 = 21000;
 #[derive(Clone)]
 pub struct Web3 {
     url: String,
-    jsonrpc_client: Arc<HttpClient>,
+    jsonrpc_client: HttpClient,
     timeout: Duration,
 }
 
 impl Web3 {
     pub fn new(url: &str, timeout: Duration) -> Self {
         Self {
-            jsonrpc_client: Arc::new(HttpClient::new(url)),
+            jsonrpc_client: HttpClient::new(url),
             timeout,
             url: url.to_string(),
         }
@@ -363,10 +363,12 @@ impl Web3 {
         }
     }
 
-
     /// Publishes a prepared transaction and returns the txhash on success. If you want to wait for the transaction
     /// to actually execute on chain, you can use `web3.wait_for_transaction()`
-    pub async fn send_prepared_transaction(&self, transaction: Transaction) -> Result<Uint256, Web3Error> {
+    pub async fn send_prepared_transaction(
+        &self,
+        transaction: Transaction,
+    ) -> Result<Uint256, Web3Error> {
         self.eth_send_raw_transaction(transaction.to_bytes()).await
     }
 

--- a/web30/src/eth_wrapping.rs
+++ b/web30/src/eth_wrapping.rs
@@ -19,9 +19,10 @@ impl Web3 {
         let tokens = [];
         let payload = encode_call(sig, &tokens).unwrap();
         let weth_address = weth_address.unwrap_or(*WETH_CONTRACT_ADDRESS);
-        let txid = self
-            .send_transaction(weth_address, payload, amount, secret, vec![])
+        let tx = self
+            .prepare_transaction(weth_address, payload, amount, secret, vec![])
             .await?;
+        let txid = self.eth_send_raw_transaction(tx.to_bytes()).await?;
 
         if let Some(timeout) = wait_timeout {
             future_timeout(timeout, self.wait_for_transaction(txid, timeout, None)).await??;
@@ -40,9 +41,10 @@ impl Web3 {
         let tokens = [AbiToken::Uint(amount)];
         let payload = encode_call(sig, &tokens).unwrap();
         let weth_address = weth_address.unwrap_or(*WETH_CONTRACT_ADDRESS);
-        let txid = self
-            .send_transaction(weth_address, payload, 0u16.into(), secret, vec![])
+        let tx = self
+            .prepare_transaction(weth_address, payload, 0u16.into(), secret, vec![])
             .await?;
+        let txid = self.eth_send_raw_transaction(tx.to_bytes()).await?;
 
         if let Some(timeout) = wait_timeout {
             future_timeout(timeout, self.wait_for_transaction(txid, timeout, None)).await??;

--- a/web30/src/jsonrpc/client.rs
+++ b/web30/src/jsonrpc/client.rs
@@ -10,6 +10,7 @@ use std::str;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+#[derive(Clone)]
 pub struct HttpClient {
     id_counter: Arc<Mutex<RefCell<u64>>>,
     url: String,


### PR DESCRIPTION
This patch splits the prepare and tx publish roles. For a long time we've had send_transaction fully abstract the lower level details of making a payment. But this doesn't cover possible cases where a transaction has been handed off to a full node, and could potentially not be published.

In order to resolve these cases robustly we leave it on the user to do final publishing, having access to the transaction object the caller can retireve the txhash and perform some informed queries to discover if it was actually published despite the full node returning an error.