### PR TITLE
Fix misleading response decoding error

### DIFF
--- a/web30/src/jsonrpc/client.rs
+++ b/web30/src/jsonrpc/client.rs
@@ -69,7 +69,7 @@ impl HttpClient {
             Ok(val) => val,
             Err(e) => {
                 return Err(Web3Error::BadResponse(format!(
-                    "Size Limit {request_size_limit} Web3 Error {e}"
+                    "Failed to process response: {e}"
                 )))
             }
         };


### PR DESCRIPTION
For instance in v1.5 a `eth_getBlockByNumber` call that didn't contain the `totalDifficulty` field would fail with:
```
BadResponse("Size Limit 2961844000 Web3 Error Json deserialize error:
data did not match any variant of untagged enum ResponseData...")
```
While in fact it has nothing to do with the size limit. After this change the error would be:
```
BadResponse("Failed to process response: Json deserialize error:
data did not match any variant of untagged enum ResponseData...")
```

If the error ends up being buffer size limit related, the message is still explicit enough:
```
BadResponse("Failed to process response:
Error that occur during reading payload: payload reached size limit")
```

Also refs https://github.com/althea-net/web30/pull/17