### PR TITLE
Allow for tx options to be used when simulating transactions

### DIFF
--- a/web30/Cargo.toml
+++ b/web30/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web30"
-version = "1.11.3"
+version = "1.12.0"
 authors = ["Michal Papierski", "Jehan Tremback", "Justin Kilpatrick"]
 description = "Async endian safe web3 library"
 license = "Apache-2.0"

--- a/web30/src/amm.rs
+++ b/web30/src/amm.rs
@@ -94,6 +94,7 @@ impl Web3 {
         let amounts_bytes = self
             .simulate_transaction(
                 TransactionRequest::quick_tx(caller_address, router, payload),
+                vec![],
                 None,
             )
             .await?;
@@ -341,6 +342,7 @@ impl Web3 {
         let result = self
             .simulate_transaction(
                 TransactionRequest::quick_tx(caller_address, quoter, payload),
+                vec![],
                 None,
             )
             .await?;
@@ -585,7 +587,7 @@ impl Web3 {
         }
 
         let allowance = self
-            .get_erc20_allowance(token_in, eth_address, router)
+            .get_erc20_allowance(token_in, eth_address, router, options.clone())
             .await?;
         if allowance < amount {
             debug!("token_in being approved");
@@ -862,6 +864,7 @@ impl Web3 {
         let pool_result = self
             .simulate_transaction(
                 TransactionRequest::quick_tx(caller_address, factory, payload),
+                vec![],
                 None,
             )
             .await?;
@@ -903,6 +906,7 @@ impl Web3 {
         let token_result = self
             .simulate_transaction(
                 TransactionRequest::quick_tx(caller_address, pool_addr, payload),
+                vec![],
                 None,
             )
             .await?;
@@ -934,6 +938,7 @@ impl Web3 {
         let slot0_result = self
             .simulate_transaction(
                 TransactionRequest::quick_tx(caller_address, pool_addr, payload),
+                vec![],
                 None,
             )
             .await?;
@@ -1468,11 +1473,11 @@ fn swap_hardhat_test() {
             panic!("Failed to wrap eth before testing uniswap");
         }
         let initial_weth = web3
-            .get_erc20_balance(*WETH_CONTRACT_ADDRESS, miner_address)
+            .get_erc20_balance(*WETH_CONTRACT_ADDRESS, miner_address, vec![])
             .await
             .unwrap();
         let initial_dai = web3
-            .get_erc20_balance(*DAI_CONTRACT_ADDRESS, miner_address)
+            .get_erc20_balance(*DAI_CONTRACT_ADDRESS, miner_address, vec![])
             .await
             .unwrap();
 
@@ -1500,11 +1505,11 @@ fn swap_hardhat_test() {
             panic!("Error performing first swap: {:?}", result.err());
         }
         let executing_weth = web3
-            .get_erc20_balance(*WETH_CONTRACT_ADDRESS, miner_address)
+            .get_erc20_balance(*WETH_CONTRACT_ADDRESS, miner_address, vec![])
             .await
             .unwrap();
         let executing_dai = web3
-            .get_erc20_balance(*DAI_CONTRACT_ADDRESS, miner_address)
+            .get_erc20_balance(*DAI_CONTRACT_ADDRESS, miner_address, vec![])
             .await
             .unwrap();
         info!(
@@ -1533,11 +1538,11 @@ fn swap_hardhat_test() {
             panic!("Error performing second swap: {:?}", result.err());
         }
         let final_weth = web3
-            .get_erc20_balance(*WETH_CONTRACT_ADDRESS, miner_address)
+            .get_erc20_balance(*WETH_CONTRACT_ADDRESS, miner_address, vec![])
             .await
             .unwrap();
         let final_dai = web3
-            .get_erc20_balance(*DAI_CONTRACT_ADDRESS, miner_address)
+            .get_erc20_balance(*DAI_CONTRACT_ADDRESS, miner_address, vec![])
             .await
             .unwrap();
         info!("Final WETH: {}, Final DAI: {}", final_weth, final_dai);
@@ -1586,11 +1591,11 @@ fn swap_hardhat_eth_in_test() {
 
         let initial_eth = web3.eth_get_balance(miner_address).await.unwrap();
         let initial_weth = web3
-            .get_erc20_balance(*WETH_CONTRACT_ADDRESS, miner_address)
+            .get_erc20_balance(*WETH_CONTRACT_ADDRESS, miner_address, vec![])
             .await
             .unwrap();
         let initial_dai = web3
-            .get_erc20_balance(*DAI_CONTRACT_ADDRESS, miner_address)
+            .get_erc20_balance(*DAI_CONTRACT_ADDRESS, miner_address, vec![])
             .await
             .unwrap();
 
@@ -1617,11 +1622,11 @@ fn swap_hardhat_eth_in_test() {
         }
         let final_eth = web3.eth_get_balance(miner_address).await.unwrap();
         let final_weth = web3
-            .get_erc20_balance(*WETH_CONTRACT_ADDRESS, miner_address)
+            .get_erc20_balance(*WETH_CONTRACT_ADDRESS, miner_address, vec![])
             .await
             .unwrap();
         let final_dai = web3
-            .get_erc20_balance(*DAI_CONTRACT_ADDRESS, miner_address)
+            .get_erc20_balance(*DAI_CONTRACT_ADDRESS, miner_address, vec![])
             .await
             .unwrap();
         info!(

--- a/web30/src/erc20_permit.rs
+++ b/web30/src/erc20_permit.rs
@@ -1,3 +1,5 @@
+use std::vec;
+
 use clarity::{abi::encode_call, utils::bytes_to_hex_str, Address};
 use num256::Uint256;
 use num_traits::ToPrimitive;
@@ -20,6 +22,7 @@ impl Web3 {
         let nonces = self
             .simulate_transaction(
                 TransactionRequest::quick_tx(caller_address, erc20, payload),
+                vec![],
                 None,
             )
             .await?;
@@ -44,6 +47,7 @@ impl Web3 {
         let domain_res = self
             .simulate_transaction(
                 TransactionRequest::quick_tx(caller_address, erc20, payload),
+                vec![],
                 None,
             )
             .await?;

--- a/web30/src/erc721_utils.rs
+++ b/web30/src/erc721_utils.rs
@@ -23,12 +23,14 @@ impl Web3 {
         erc721: Address,
         own_address: Address,
         token_id: Uint256,
+        options: Vec<SendTxOption>,
     ) -> Result<Option<EthAddress>, Web3Error> {
         let payload = encode_call("getApproved(uint256)", &[AbiToken::Uint(token_id)])?;
 
         let val = self
             .simulate_transaction(
                 TransactionRequest::quick_tx(own_address, erc721, payload),
+                options,
                 None,
             )
             .await?;
@@ -180,11 +182,13 @@ impl Web3 {
         &self,
         erc721: Address,
         caller_address: Address,
+        options: Vec<SendTxOption>,
     ) -> Result<String, Web3Error> {
         let payload = encode_call("name()", &[])?;
         let name = self
             .simulate_transaction(
                 TransactionRequest::quick_tx(caller_address, erc721, payload),
+                options,
                 None,
             )
             .await?;
@@ -210,11 +214,13 @@ impl Web3 {
         &self,
         erc721: Address,
         caller_address: Address,
+        options: Vec<SendTxOption>,
     ) -> Result<String, Web3Error> {
         let payload = encode_call("symbol()", &[])?;
         let symbol = self
             .simulate_transaction(
                 TransactionRequest::quick_tx(caller_address, erc721, payload),
+                options,
                 None,
             )
             .await?;
@@ -240,11 +246,13 @@ impl Web3 {
         &self,
         erc721: Address,
         caller_address: Address,
+        options: Vec<SendTxOption>,
     ) -> Result<Uint256, Web3Error> {
         let payload = encode_call("totalSupply()", &[])?;
         let decimals = self
             .simulate_transaction(
                 TransactionRequest::quick_tx(caller_address, erc721, payload),
+                options,
                 None,
             )
             .await?;
@@ -267,11 +275,13 @@ impl Web3 {
         erc721: Address,
         caller_address: Address,
         token_id: Uint256,
+        options: Vec<SendTxOption>,
     ) -> Result<String, Web3Error> {
         let payload = encode_call("tokenURI(uint256)", &[AbiToken::Uint(token_id)])?;
         let symbol = self
             .simulate_transaction(
                 TransactionRequest::quick_tx(caller_address, erc721, payload),
+                options,
                 None,
             )
             .await?;
@@ -298,12 +308,14 @@ impl Web3 {
         erc721: Address,
         own_address: Address,
         token_id: Uint256,
+        options: Vec<SendTxOption>,
     ) -> Result<EthAddress, Web3Error> {
         let payload = encode_call("ownerOf(uint256)", &[AbiToken::Uint(token_id)])?;
 
         let val = self
             .simulate_transaction(
                 TransactionRequest::quick_tx(own_address, erc721, payload),
+                options,
                 None,
             )
             .await?;
@@ -337,25 +349,25 @@ fn test_erc721_metadata() {
     runner.block_on(async move {
         let num: Uint256 = 1000u32.into();
         assert!(
-            web3.get_erc721_supply(bayc_address, caller_address)
+            web3.get_erc721_supply(bayc_address, caller_address, vec![])
                 .await
                 .unwrap()
                 > num
         );
         assert_eq!(
-            web3.get_erc721_symbol(bayc_address, caller_address)
+            web3.get_erc721_symbol(bayc_address, caller_address, vec![])
                 .await
                 .unwrap(),
             "BAYC"
         );
         assert_eq!(
-            web3.get_erc721_name(bayc_address, caller_address)
+            web3.get_erc721_name(bayc_address, caller_address, vec![])
                 .await
                 .unwrap(),
             "BoredApeYachtClub"
         );
         assert_eq!(
-            web3.get_erc721_uri(bayc_address, caller_address, token_id_uint)
+            web3.get_erc721_uri(bayc_address, caller_address, token_id_uint, vec![])
                 .await
                 .unwrap(),
             token_id_uri

--- a/web30/src/types.rs
+++ b/web30/src/types.rs
@@ -621,7 +621,7 @@ impl TransactionRequest {
         }
     }
     /// A specialized gas price setter for simulations, EIP1559 gas is treated very differently on actual execution but
-    /// for hte purpose of simulation it makes sense to set the value super high and see what results we get.
+    /// for the purpose of simulation it makes sense to set the value super high and see what results we get.
     pub fn set_gas_price(&mut self, new_gas_price: Uint256) {
         match self {
             TransactionRequest::Eip1559 {
@@ -631,6 +631,24 @@ impl TransactionRequest {
             | TransactionRequest::Legacy { gas_price, .. } => {
                 *gas_price = Some(new_gas_price.into())
             }
+        }
+    }
+    pub fn set_priority_fee(&mut self, new_priority_fee: Uint256) {
+        match self {
+            TransactionRequest::Eip1559 {
+                max_priority_fee_per_gas,
+                ..
+            } => *max_priority_fee_per_gas = Some(new_priority_fee.into()),
+            TransactionRequest::Eip2930 { .. } | TransactionRequest::Legacy { .. } => {}
+        }
+    }
+    pub fn set_access_list(&mut self, new_access_list: Vec<(Address, Vec<Uint256>)>) {
+        match self {
+            TransactionRequest::Eip1559 { access_list, .. }
+            | TransactionRequest::Eip2930 { access_list, .. } => {
+                *access_list = convert_access_list(new_access_list);
+            }
+            TransactionRequest::Legacy { .. } => {}
         }
     }
     pub fn is_eip1559(&self) -> bool {


### PR DESCRIPTION
These may be useful when a user needs to tweak a simulation call